### PR TITLE
AA-27632:Add GitHub workflow to Configure  AWS credentials for shared service, dev, stage, and prod env for deployment

### DIFF
--- a/.docs/configure-aws-credential.md
+++ b/.docs/configure-aws-credential.md
@@ -1,0 +1,45 @@
+# configure-aws-credential
+
+This GitHub Workflow:
+Configure your AWS credentials and region environment variables for use in other GitHub Actions. This action implements the AWS SDK credential resolution chain and exports environment variables for your other Actions to use. Environment variable exports are detected by both the AWS SDKs and the AWS CLI for AWS API calls
+
+# Usage
+
+- For any armor repositories where we are deploying to aws can use this workflow to assume role to shared service and then assume role to required environment(dev,stage,prod).
+- The armor aws shared service account uses OpenID Connect (OIDC) which allows your GitHub Actions workflows to access resources in Amazon Web Services (AWS), without needing to store the AWS credentials as long-lived GitHub secrets.
+
+## Create GitHub Workflow
+
+```yaml
+name: 'cd'
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+
+  cd:
+    - name: Assume Role
+      uses: armor/actions/.github/workflows/configure-aws-credentials.yaml@main
+      with:
+        AWS_SHARED_ACCOUNT_ID: arn:aws:iam::${{ env.awsSharedAccountId }}
+        AWS_ACCOUNT_ID: ${{ env.awsAccountId }}
+        AWS_REGION: ${{ env.region }}
+        GITHUB_JOB: ${{ env.githubJob }}
+        GITHUB_RUN_ATTEMPT: ${{ env.githubRunAttempt }}
+        GITHUB_REPO_NAME: ${{ inputs.repoName }}
+
+    - name: Sts GetCallerIdentity
+      if: success()
+      run: |
+        aws sts get-caller-identity
+
+    - name: Deploy
+      run: sls deploy ##Deploy serverless or deploy to aws s3 
+```

--- a/.github/workflows/configure-aws-credentials.yaml
+++ b/.github/workflows/configure-aws-credentials.yaml
@@ -15,7 +15,7 @@ on:
         description: "AWS Region used for deployment"
         required: true
         default: "us-west-2"
-      AWGITHUB_JOB:
+      GITHUB_JOB:
         type: "string"
         description: "GitHub job id used to identify role session name"
         required: true

--- a/.github/workflows/configure-aws-credentials.yaml
+++ b/.github/workflows/configure-aws-credentials.yaml
@@ -4,11 +4,11 @@ on:
     inputs:
       AWS_SHARED_ACCOUNT_ID:
         type: "string"
-        description: "AWS Shared Service Account Id"
+        description: "Armor AWS Shared Service Account Id"
         required: true
       AWS_ACCOUNT_ID:
         type: "string"
-        description: "AWS Account Id for Dev/Stage/Prod"
+        description: "Armor AWS Account Id for Dev/Stage/Prod"
         required: true
       AWS_REGION:
         type: "string"

--- a/.github/workflows/configure-aws-credentials.yaml
+++ b/.github/workflows/configure-aws-credentials.yaml
@@ -1,0 +1,57 @@
+name: Armor Configure AWS Credentials
+on:
+  workflow_call:
+    inputs:
+      AWS_SHARED_ACCOUNT_ID:
+        type: "string"
+        description: "AWS Shared Service Account Id"
+        required: true
+      AWS_ACCOUNT_ID:
+        type: "string"
+        description: "AWS Account Id for Dev/Stage/Prod"
+        required: true
+      AWS_REGION:
+        type: "string"
+        description: "AWS Region used for deployment"
+        required: true
+        default: "us-west-2"
+      AWGITHUB_JOB:
+        type: "string"
+        description: "GitHub job id used to identify role session name"
+        required: true
+        default: ""
+      GITHUB_RUN_ATTEMPT:
+        type: "string"
+        description: "GitHub Run Attempt used to identify role session name"
+        required: true
+        default: ""
+      GITHUB_REPO_NAME:
+        type: "string"
+        description: "GitHub Repo Name used to identify role session name"
+        required: true
+        default: ""
+
+jobs:
+
+  assume-role:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Assume Role Shared Service
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.AWS_SHARED_ACCOUNT_ID }}:role/allow-auto-deploy-from-code-deploy
+          role-session-name: ${{ inputs.GITHUB_REPO_NAME }}-${{ inputs.AWGITHUB_JOB }}@${{ inputs.GITHUB_RUN_ATTEMPT }}
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-skip-session-tagging: true
+          output-credentials: true
+
+      - name: Assume Role Dev/Stage/Prod
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/allow-auto-deploy-from-other-accounts
+          # Session id must be [A-Za-z_=,.@-] and <= 64 characters
+          role-session-name: ${{ inputs.GITHUB_REPO_NAME }}-${{ inputs.AWS_SHARED_ACCOUNT_ID }}@${{ inputs.GITHUB_RUN_ATTEMPT }}
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-skip-session-tagging: true
+          role-chaining: true


### PR DESCRIPTION
https://armor-defense.atlassian.net/browse/AA-27388- Parent Task
https://armor-defense.atlassian.net/browse/AA-27632

Configure AWS credentials and region environment variables for use in other GitHub Actions. This action implements the AWS SDK credential resolution chain and exports environment variables for your other Actions to use.